### PR TITLE
added datadog support - issue #9

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ The following metrics are produced by the app in statsd:
 +------------------------------+---------+------------------------------------------+
 | absearch.discarded           | counter | on every cohort discard (*) (**)         |
 +------------------------------+---------+------------------------------------------+
-| absearch.refresh             | counter | on every call to get cohort settings (*) |
+| absearch.refreshed           | counter | on every call to get cohort settings (*) |
 +------------------------------+---------+------------------------------------------+
 | absearch.get_cohort_settings | timer   | on every GET to get back cohort settings |
 +------------------------------+---------+------------------------------------------+

--- a/README.rst
+++ b/README.rst
@@ -61,8 +61,16 @@ The following metrics are produced by the app in statsd:
 +------------------------------+---------+------------------------------------------+
 | absearch.add_user_to_cohort  | timer   | on every GET w/ a new cohort set         |
 +------------------------------+---------+------------------------------------------+
-| absearch.cohorts.*           | counter | on every cohort set                      |
+| absearch.enrolled            | counter | on every cohort enrollment (*)           |
++------------------------------+---------+------------------------------------------+
+| absearch.discarded           | counter | on every cohort discard (*) (**)         |
++------------------------------+---------+------------------------------------------+
+| absearch.refresh             | counter | on every call to get cohort settings (*) |
 +------------------------------+---------+------------------------------------------+
 | absearch.get_cohort_settings | timer   | on every GET to get back cohort settings |
 +------------------------------+---------+------------------------------------------+
+
+
+(*) if you use Datadog, the tag will contain the cohort name, prefixed by the locale and territory.
+(**) unknown cohorts will increment this counter as well
 

--- a/absearch/server.py
+++ b/absearch/server.py
@@ -197,7 +197,7 @@ def get_cohort_settings(**kw):
                 app._statsd.incr('discarded', tags=[asked_cohort])
             else:
                 # we're getting back the cohort settings
-                app._statsd.incr('refresh', tags=[asked_cohort])
+                app._statsd.incr('refreshed', tags=[asked_cohort])
 
             return res
 

--- a/absearch/server.py
+++ b/absearch/server.py
@@ -10,6 +10,7 @@ import hashlib
 from konfig import Config
 from bottle import Bottle, HTTPError
 from statsd import StatsClient
+from datadog import initialize, statsd
 from raven import Client as Sentry
 
 from absearch import __version__
@@ -37,6 +38,34 @@ gevent.signal(signal.SIGTERM, close)
 gevent.signal(signal.SIGINT, close)
 
 
+class _Statsd(object):
+    def __init__(self, config):
+        if config.get('datadog', True):
+            initialize(statsd_host=config['host'],
+                       statsd_port=config['port'],
+                       prefix=config['prefix'])
+            self.datadog = True
+            self._statsd = statsd
+        else:
+            self.datadog = False
+            self._statsd = StatsClient(config['host'],
+                                       config['port'],
+                                       config['prefix'])
+
+    def incr(self, metric, count=1, rate=1, **kw):
+        if self.datadog:
+            return self._statsd.increment(metric, value=count,
+                                          sample_rate=rate, **kw)
+        else:
+            return self._statsd.incr(metric, count=count, rate=rate)
+
+    def timer(self, metric, rate=1, **kw):
+        if self.datadog:
+            return self._statsd.timed(metric, sample_rate=rate, **kw)
+        else:
+            return self._statsd.timer(metric, rate=rate)
+
+
 def initialize_app(config):
     app._config_file = config
     app._config = Config(config)
@@ -45,9 +74,7 @@ def initialize_app(config):
     logging.config.fileConfig(config)
 
     # statsd configuration
-    app._statsd = StatsClient(app._config['statsd']['host'],
-                              app._config['statsd']['port'],
-                              prefix=app._config['statsd']['prefix'])
+    app._statsd = _Statsd(app._config['statsd'])
 
     # sentry configuration
     if app._config['sentry']['enabled']:
@@ -142,9 +169,11 @@ def add_user_to_cohort(**kw):
             raise HTTPError(status=404)
 
         cohort = res.get('cohort', 'default')
-        cohort = '.'.join(['cohorts', kw['locale'],
-                           kw['territory'], cohort])
-        app._statsd.incr(cohort)
+        if cohort != 'default':
+            locale = kw['locale']
+            territory = kw['territory']
+            cohort = '.'.join([locale, territory, cohort])
+            app._statsd.incr('enrolled', tags=[cohort])
         return res
 
 
@@ -152,7 +181,26 @@ def add_user_to_cohort(**kw):
 def get_cohort_settings(**kw):
     with app._statsd.timer('get_cohort_settings'):
         try:
-            return app.settings.get(**kw)
+            asked_cohort = kw['cohort']
+            res = app.settings.get(**kw)
+            if asked_cohort == 'default':
+                return res
+
+            cohort = res.get('cohort', 'default')
+            locale = kw['locale']
+            territory = kw['territory']
+            asked_cohort = '.'.join([locale, territory, asked_cohort])
+            cohort = '.'.join([locale, territory, cohort])
+
+            if asked_cohort != cohort:
+                # we're getting discarded
+                app._statsd.incr('discarded', tags=[asked_cohort])
+            else:
+                # we're getting back the cohort settings
+                app._statsd.incr('refresh', tags=[asked_cohort])
+
+            return res
+
         except ValueError:
             raise HTTPError(status=404)
 

--- a/absearch/tests/absearch-nodatadog.ini
+++ b/absearch/tests/absearch-nodatadog.ini
@@ -1,0 +1,64 @@
+[absearch]
+host = 0.0.0.0
+port = 7654
+server = gevent
+debug = 1
+config = config.json
+schema = config.schema.json
+max_age = 3600
+backend = aws
+counter = redis
+
+[redis]
+host = 0.0.0.0
+db = 0
+port = 7777
+
+[aws]
+bucketname = absearch
+is_secure = 0
+host = 0.0.0.0
+port = 5000
+use_path_style = 1
+timeout = 0.2
+num_retries = 2
+
+[statsd]
+host = localhost
+port = 8125
+prefix = meh
+datadog = 0
+
+[sentry]
+enabled = 0
+dsn = http://somekey:secret@localhost/absearch
+
+[loggers]
+keys = root,absearch
+
+[handlers]
+keys = consoleHandler
+
+[formatters]
+keys = simpleFormatter
+
+[logger_root]
+level = DEBUG
+handlers = consoleHandler
+
+[logger_absearch]
+level = DEBUG
+handlers = consoleHandler
+qualname = absearch
+propagate = 0
+
+[handler_consoleHandler]
+class = StreamHandler
+level = DEBUG
+formatter = simpleFormatter
+args = (sys.stdout,)
+
+[formatter_simpleFormatter]
+format = %(asctime)s - %(name)s - %(levelname)s - %(message)s
+datefmt =
+

--- a/absearch/tests/support.py
+++ b/absearch/tests/support.py
@@ -35,6 +35,8 @@ def run_redis():
 
 _P = []
 test_config = os.path.join(os.path.dirname(__file__), 'absearch.ini')
+test_config_no_datadog = os.path.join(os.path.dirname(__file__),
+                                      'absearch-nodatadog.ini')
 
 
 def runServers():
@@ -87,10 +89,13 @@ def stopServers():
     _P[:] = []
 
 
-def get_app():
+def get_app(datadog=True):
     # create the web app
     server.app.debug = True
-    server.initialize_app(test_config)
+    if datadog:
+        server.initialize_app(test_config)
+    else:
+        server.initialize_app(test_config_no_datadog)
     server.app.catchall = False
     return TestApp(server.app)
 

--- a/absearch/tests/test_aws.py
+++ b/absearch/tests/test_aws.py
@@ -21,6 +21,7 @@ def test_get_set_s3_file():
         @contextmanager
         def timer(self, name):
             yield
+        timed = timer
 
     stats = Stats()
     config = Config(test_config)

--- a/absearch/tests/test_metrics.py
+++ b/absearch/tests/test_metrics.py
@@ -80,10 +80,9 @@ def test_enrolled():
     path = '/1/firefox/39/beta/cs-CZ/cz/default/default/' + cohort
     res = app.get(path)
 
-    assert stats.counters['refresh'] == 1
+    assert stats.counters['refreshed'] == 1
 
-    # also, an unexistant cohort should fall back to the default
-    # and count as a discard as well
+    # also, an unexistant cohort should be counted as a discard
     path = '/1/firefox/39/beta/cs-CZ/cz/default/default/meh'
     app.get(path)
     assert stats.counters['discarded'] == 1

--- a/absearch/tests/test_server.py
+++ b/absearch/tests/test_server.py
@@ -79,9 +79,17 @@ def test_weird_locale_name():
     assert res.json['settings']['searchDefault'] in wanted
 
 
-def test_set_cohort2():
-    app = get_app()
+def test_set_cohort2_statsd():
+    app = get_app(datadog=False)
+    return _test_set_cohort2(app)
 
+
+def test_set_cohort2_datadog():
+    app = get_app()
+    return _test_set_cohort2(app)
+
+
+def _test_set_cohort2(app):
     # get a cohort
     path = '/1/firefox/39/beta/cs-CZ/cz/default/default'
     res = app.get(path)

--- a/config/absearch.ini
+++ b/config/absearch.ini
@@ -68,6 +68,8 @@ num_retries = 1
 host = localhost
 port = 8125
 prefix = absearch
+# by default set to 1. If set to 0, uses plain statsd
+datadog = 1
 
 [sentry]
 enabled = 0

--- a/data/config.json
+++ b/data/config.json
@@ -33,7 +33,8 @@
         "tests": {
           "fooBaz": {
             "settings": {
-              "searchDefault": "Google"
+              "searchDefault": "Google",
+              "extra": "key"
             },
             "filters": {
               "sampleRate": 100,

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ install_requires = ['gevent==1.1rc3',
                     'redis==2.10.3',
                     'konfig==0.9',
                     'statsd==3.1',
+                    'datadog==0.10.0',
                     'raven==5.3.1']
 
 classifiers = ["Programming Language :: Python",


### PR DESCRIPTION
This PR changes the statsd metrics and adds those three counters:

- enrolled  (with tags=cohort name if you use datadog)
- discarded (with tags=discarded cohort name if you use datadog)
- refresh  (with tags=cohort name if you use datadog)

By default it will use datadog, unless you set a flag to False in the [statsd] sections.

cc @Micheletto @mconnormoz 
