### PR TITLE
Bug 1304192 - Map prerelease channels to regular channels

### DIFF
--- a/absearch/settings.py
+++ b/absearch/settings.py
@@ -146,8 +146,9 @@ class SearchSettings(object):
             ver = int(ver.split('.')[0])
         except ValueError:
             raise ValueError("Bad version")
-        # Allow for prerelease channels (release-cdntest, beta-cdntest)
-        channel = _lower(channel).split('-')[0]
+        channel = _lower(channel)
+        # Allow for prerelease channels (release-localtest, beta-cdntest)
+        channel = channel.replace('-cdntest', '').replace('-localtest', '')
         dist = _lower(dist)
         distver = _lower(distver)
 

--- a/absearch/settings.py
+++ b/absearch/settings.py
@@ -146,7 +146,8 @@ class SearchSettings(object):
             ver = int(ver.split('.')[0])
         except ValueError:
             raise ValueError("Bad version")
-        channel = _lower(channel)
+        # Allow for prerelease channels (release-cdntest, beta-cdntest)
+        channel = _lower(channel).split('-')[0]
         dist = _lower(dist)
         distver = _lower(distver)
 

--- a/absearch/tests/test_server.py
+++ b/absearch/tests/test_server.py
@@ -267,6 +267,16 @@ def test_channel_filter():
     res = app.get(path)
     assert 'cohort' not in res.json, res.json
 
+    # cdntest should map to regular channel
+    path = '/1/firefox/39/beta-cdntest/fr-FR/fr/default/default'
+    res = app.get(path)
+    assert res.json.get('cohort') == 'fooBaz', res.json
+
+    # localtest should map to regular channel
+    path = '/1/firefox/39/release-localtest/fr-FR/fr/default/default'
+    res = app.get(path)
+    assert res.json.get('cohort') == 'fooBaz', res.json
+
 
 def test_version_filter():
     flush_redis()


### PR DESCRIPTION
When attempting to test absearch with prerelease Firefox, I ran into problems because for prerelease, all the channels are prefixed:

release-cdntest
beta-cdntest

The logical fix seemed to be to have absearch match the prefix of the channel as the channel for testing cohorts and this seemed like the best way to accomplish that.
