### PR TITLE
If the cohort is not valid, check for a new cohort

### DIFF
--- a/absearch/settings.py
+++ b/absearch/settings.py
@@ -178,6 +178,8 @@ class SearchSettings(object):
             res, picked_cohort = self._get_cohort(locale, territory, cohort)
             if picked_cohort != 'default':
                 res['cohort'] = picked_cohort
+            else:
+                res = self._pick_cohort(locale, territory, prod, ver, channel)
         else:
             # pick one
             res = self._pick_cohort(locale, territory, prod, ver, channel)


### PR DESCRIPTION
Currently if an invalid cohort is specified, it is ignored and we pick the default value.

This is not correct. There might be other cohorts that still fit the bill. We should check them.