### PR TITLE
Remove `retry` from deploy-dockerhub.sh

### DIFF
--- a/scripts/deploy-dockerhub.sh
+++ b/scripts/deploy-dockerhub.sh
@@ -1,28 +1,9 @@
 #!/bin/bash
 
-# THIS IS MEANT TO BE RUN BY CI
-
 set -e
 
-# Usage: retry MAX CMD...
-# Retry CMD up to MAX times. If it fails MAX times, returns failure.
-# Example: retry 3 docker push "$DOCKERHUB_REPO:$TAG"
-function retry() {
-    max=$1
-    shift
-    count=1
-    until "$@"; do
-        count=$((count + 1))
-        if [[ $count -gt $max ]]; then
-            return 1
-        fi
-        echo "$count / $max"
-    done
-    return 0
-}
-
 # configure docker creds
-retry 3  echo "$DOCKER_PASS" | docker login -u="$DOCKER_USER" --password-stdin
+echo "$DOCKER_PASS" | docker login -u="$DOCKER_USER" --password-stdin
 
 # docker tag and push git branch to dockerhub
 if [ -n "$1" ]; then

--- a/scripts/deploy-dockerhub.sh
+++ b/scripts/deploy-dockerhub.sh
@@ -10,7 +10,7 @@ if [ -n "$1" ]; then
     [ "$1" == master ] && TAG=latest || TAG="$1"
     docker tag app:build "$DOCKERHUB_REPO:$TAG" ||
         (echo "Couldn't tag app:build as $DOCKERHUB_REPO:$TAG" && false)
-    retry 3 docker push "$DOCKERHUB_REPO:$TAG" ||
+    docker push "$DOCKERHUB_REPO:$TAG" ||
         (echo "Couldn't push $DOCKERHUB_REPO:$TAG" && false)
     echo "Pushed $DOCKERHUB_REPO:$TAG"
 fi


### PR DESCRIPTION
This was a copy/pasta piece of code from various repos that was originally created to work around network issues in normandy pushing to Dockerhub.  It's not required anymore.  