### PR TITLE
Restore default WSGI engine

### DIFF
--- a/config/absearch.ini
+++ b/config/absearch.ini
@@ -1,5 +1,8 @@
 [absearch]
 
+# WSGI adapter.
+server = auto
+
 # the host to start the web service.
 host = 0.0.0.0
 


### PR DESCRIPTION
Follow-up of #211 

Without a default value for the `server` param, it would fail starting with :
```
Traceback (most recent call last):
  File "/home/mathieu/Code/Mozilla/absearch/.venv/bin/absearch-server", line 11, in <module>
    load_entry_point('absearch', 'console_scripts', 'absearch-server')()
  File "/home/mathieu/Code/Mozilla/absearch/absearch/server.py", line 255, in main
    server=abconf['server'], debug=abconf['debug'],
  File "/home/mathieu/Code/Mozilla/absearch/.venv/local/lib/python2.7/site-packages/backports/configparser/__init__.py", line 1359, in __getitem__
    raise KeyError(key)
KeyError: 'server'
```

Instead of removing the `server=` parameter of `run()` I decided to set a default value in config. During the deployment of this new version, we can choose to use a multi-threaded one like `waitress` or `paste` if the performance is poor. But now that we serve static data, we can cache as much as we can and the default might just be enough.